### PR TITLE
v1.1.2 Minor fixes mostly with user-specified noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bayesian Adaptive Direct Search (BADS) - v1.1.1
+# Bayesian Adaptive Direct Search (BADS) - v1.1.2
 
 #### News 
 - 31/Oct/22: BADS 1.1.1 released! Added full support for user-specified noise (e.g., for heteroskedastic targets) and several fixes.

--- a/bads.m
+++ b/bads.m
@@ -1,5 +1,5 @@
 function [x,fval,exitflag,output,optimState,gpstruct] = bads(fun,x0,LB,UB,PLB,PUB,nonbcon,options,varargin)
-%BADS Constrained optimization using Bayesian Adaptive Direct Search (v1.1.1)
+%BADS Constrained optimization using Bayesian Adaptive Direct Search (v1.1.2)
 %   BADS attempts to solve problems of the form:
 %       min F(X)  subject to:  LB <= X <= UB
 %        X                        C(X) <= 0        (optional)
@@ -134,15 +134,15 @@ function [x,fval,exitflag,output,optimState,gpstruct] = bads(fun,x0,LB,UB,PLB,PU
 %   Author (copyright): Luigi Acerbi, 2017-2022
 %   e-mail: luigi.acerbi@helsinki.fi
 %   URL: http://luigiacerbi.com
-%   Version: 1.1.1
-%   Release date: Oct 31, 2022
+%   Version: 1.1.2
+%   Release date: Nov 14, 2022
 %   Code repository: https://github.com/acerbilab/bads
 %--------------------------------------------------------------------------
 
 %% Start timer
 
 t0 = tic;
-bads_version = '1.1.1';
+bads_version = '1.1.2';
 
 %% Basic default options
 
@@ -1525,3 +1525,4 @@ end
 % 1.0.8 (May/09/2022) Extra fixes to uncertainty handling and user-specified 
 %                     noise, printing, output version number.
 % 1.1.1 (Oct/31/2022) Full support for user-specified (heteroskedastic) noise.
+% 1.1.2 (Nov/14/2022) Minor fixes to heteroskedastic noise.

--- a/bads.m
+++ b/bads.m
@@ -195,7 +195,7 @@ defopts.TolStallIters           = '4 + floor(nvars/2)   % Max iterations with no
 defopts.TolNoise                = 'sqrt(eps)*options.TolFun  % Min variability for a fcn to be considered noisy';
 
 % Initialization
-defopts.Ninit                   = '10 + nvars           % Number of initial objective fcn evaluations';
+defopts.Ninit                   = 'nvars                % Number of initial objective fcn evaluations';
 defopts.InitFcn                 = '@initSobol           % Initialization function';
 % defoptions.InitFcn            = '@initLHS';
 defopts.Restarts                = '0                    % Number of restart attempts';

--- a/bads.m
+++ b/bads.m
@@ -1134,6 +1134,7 @@ end
 
 % Re-evaluate all best points for noisy evaluations
 yval_vec = yval;
+ysd_vec = [];
 if optimState.UncertaintyHandling && iter > 1    
     optimState = reevaluateIterList(optimState,gpstruct,options);
         

--- a/bads_examples.m
+++ b/bads_examples.m
@@ -266,7 +266,7 @@ options.MaxFunEvals         = 50;       % Very low budget of function evaluation
 options.Display             = 'final';  % Print only basic output ('off' turns off)
 options.UncertaintyHandling = false;    % The objective is deterministic
 
-% Custom output function, this one just ptints the iteration number 
+% Custom output function, this one just prints the iteration number 
 % (return FALSE to continue, TRUE to stop optimization)
 options.OutputFcn = @(x,optimState,state) ...
     ~isfinite(fprintf('%s %d... ', state, optimState.iter));

--- a/private/bads_output.m
+++ b/private/bads_output.m
@@ -1,4 +1,4 @@
-function output = bads_output(fun,optimState,options,LB,UB,nonbcon,iter,x,msg,yval_vec,fval,fsd,totaltime,bads_version)
+function output = bads_output(fun,optimState,options,LB,UB,nonbcon,iter,x,msg,yval_vec,ysd_vec,fval,fsd,totaltime,bads_version)
 %BADS_OUTPUT Create OUTPUT struct for BADS.
 
 output.function = func2str(fun);    
@@ -35,6 +35,9 @@ output.message = msg;
 
 % Observed function value(s) at optimum (possibly multiple samples)
 output.yval = yval_vec;
+if ~isempty(ysd_vec)
+    output.ysd = ysd_vec;
+end
 
 % Return mean and SD of the estimated function value at the optimum
 output.fval = fval;

--- a/private/setupvars.m
+++ b/private/setupvars.m
@@ -78,9 +78,10 @@ optimState.UBsearch(optimState.UBsearch > optimState.UB) = ...
 % Starting point in grid coordinates
 if any(~isfinite(x0))   % Invalid/not provided starting point
     if prnt > 0
-        fprintf('Initial starting point is invalid or not provided. Starting from center of plausible region.\n');
+        fprintf('Initial starting point is invalid or not provided.\nStarting from random point uniformly drawn from the plausible box.\n');
     end
-    u0 = force2grid(0.5*(PLB + PUB),optimState);    % Midpoint
+    u0 = rand(1,nvars).*(PUB - PLB) + PLB;
+    u0 = force2grid(u0,optimState);
     x0 = origunits(u0,optimState);
 else
     u0 = force2grid(gridunits(x0,optimState),optimState);


### PR DESCRIPTION
### v1.1.2

- Return `ysd_vec` (estimated standard deviations of final samples) in `output` for user-specified noise.
- Compute mean and std of the final estimate using `fsd` of each sample for user-specified noise.
- Revert `Ninit` default to `nvars`.
- If `x0` is not provided, sample uniformly randomly from the plausible box (instead of selecting the middle of the plausible box).